### PR TITLE
Accept camelcase phraseapp identifier

### DIFF
--- a/src/main/java/com/epages/phraseapp/PhraseAppJavascriptHeader.java
+++ b/src/main/java/com/epages/phraseapp/PhraseAppJavascriptHeader.java
@@ -9,7 +9,8 @@ public class PhraseAppJavascriptHeader {
 
     private static final String JS_SCRIPT_TEMPLATE =
             "window.PHRASEAPP_CONFIG = {\n" +
-                    "  projectId: '%s'\n" +
+                    "  projectId: '%s',\n" +
+                    "  autoLowercase: false\n" +
                     "};\n" +
                     "(function() {\n" +
                     "    var phraseapp = document.createElement('script');\n" +


### PR DESCRIPTION
> By default, the In-Context Editor document parser will convert all keys to lowercase. If you’re experiencing issues with this behavior and want to use case-sensitive keys within the In-Context Editor, you should consider disabling the auto lowercase feature:
>
> ```js
> window.PHRASEAPP_CONFIG = {
>  autoLowercase: false
> }
> ```

https://phraseapp.com/docs/guides/in-context-editor/configure/